### PR TITLE
Fixed preprocessing, path errors and updated kaggle link

### DIFF
--- a/Kasa/__init__.py
+++ b/Kasa/__init__.py
@@ -1,1 +1,1 @@
-from .preprocessing import *
+from .Preprocessing import *

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This may require obtaining some data files and accordingly passing the right pat
 # Data Files
 You will need to download two corpus (English and Twi) into a data folder on your local machine in order to run the examples, using the link below.
 
-`https://www.kaggle.com/azunre/jw300entw`
+`https://www.kaggle.com/azunre/jw300entw` or 
+`https://www.kaggle.com/datasets/azunre/twi-dataset`
 
 # Contributing
 Please first clone this repo to your local machine, using a command line tool such as Cygwin or Anaconda Prompt:

--- a/examples/load_and_preprocess_parallel_dataset.py
+++ b/examples/load_and_preprocess_parallel_dataset.py
@@ -4,6 +4,8 @@ Created on Fri Apr 17 16:20:38 2020
 
 @author: azunr
 """
+import os
+print(f"Current Directory: {os.getcwd()}")
 
 from Kasa.Preprocessing import Preprocessing # note form of library import
 
@@ -12,8 +14,8 @@ TwiPreprocessor = Preprocessing()
 
 # Read raw parallel dataset
 raw_data_twi,raw_data_en = TwiPreprocessor.read_parallel_dataset(
-        filepath_twi='../data/jw300.en-tw.tw',
-        filepath_english='../data/jw300.en-tw.en')
+        filepath_twi='./data/jw300.en-tw.tw',
+        filepath_english='./data/jw300.en-tw.en')
 
 # Normalize the raw data
 raw_data_en = [TwiPreprocessor.normalize_eng(data) for data in raw_data_en]


### PR DESCRIPTION
- I've updated the library's initialization file. The issue was that the file in the Kasa directory is named with a capital "P" (Preprocessing.py), but the import statement in __init__.py was using lowercase.
- The link to the kaggle data files were broken and led to a "not-found" page so i searched for the right link and updated tthe readme
- i also updated the path to the data files, since the files will be under the data folder in the main directory, the path should be "./" and not "../"

- After these changes the project was able to run sucessfully